### PR TITLE
Add DetailUpdate modal to Hatirlatici components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist-ssr
 .cursorrules
 .cursor
 knowledge-base.md
+project-structure.md

--- a/src/_root/components/Hatirlatici/components/Egzoz.jsx
+++ b/src/_root/components/Hatirlatici/components/Egzoz.jsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { t } from "i18next";
+import DetailUpdate from "../../../pages/vehicles-control/vehicle-detail/DetailUpdate";
 
 const { Text } = Typography;
 
@@ -126,6 +127,12 @@ const Egzoz = () => {
 
   const [selectedRows, setSelectedRows] = useState([]);
 
+  // DetailUpdate modal state
+  const [detailUpdateModal, setDetailUpdateModal] = useState({
+    isOpen: false,
+    selectedId: null,
+  });
+
   // API Data Fetching with diff and setPointId
   const fetchData = async (diff, targetPage) => {
     setLoading(true);
@@ -197,7 +204,23 @@ const Egzoz = () => {
   };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    // Open DetailUpdate modal with the vehicle's aracId
+    setDetailUpdateModal({
+      isOpen: true,
+      selectedId: record.aracId,
+    });
+  };
+
+  const handleDetailUpdateClose = () => {
+    setDetailUpdateModal({
+      isOpen: false,
+      selectedId: null,
+    });
+  };
+
+  const handleDetailUpdateSuccess = () => {
+    // Refresh table data after successful update
+    refreshTableData();
   };
 
   const refreshTableData = useCallback(() => {
@@ -509,6 +532,15 @@ const Egzoz = () => {
 
   return (
     <>
+      {/* DetailUpdate Modal */}
+      <DetailUpdate
+        isOpen={detailUpdateModal.isOpen}
+        onClose={handleDetailUpdateClose}
+        selectedId={detailUpdateModal.selectedId}
+        onSuccess={handleDetailUpdateSuccess}
+        selectedRows1={selectedRows}
+      />
+
       {/* Modal for managing columns */}
       <Modal title="Sütunları Yönet" centered width={800} open={isModalVisible} onOk={() => setIsModalVisible(false)} onCancel={() => setIsModalVisible(false)}>
         <Text style={{ marginBottom: "15px" }}>Aşağıdaki Ekranlardan Sütunları Göster / Gizle ve Sıralamalarını Ayarlayabilirsiniz.</Text>

--- a/src/_root/components/Hatirlatici/components/Kiralama.jsx
+++ b/src/_root/components/Hatirlatici/components/Kiralama.jsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { t } from "i18next";
+import DetailUpdate from "../../../pages/vehicles-control/vehicle-detail/DetailUpdate";
 
 const { Text } = Typography;
 
@@ -126,6 +127,12 @@ const Kiralama = () => {
 
   const [selectedRows, setSelectedRows] = useState([]);
 
+  // DetailUpdate modal state
+  const [detailUpdateModal, setDetailUpdateModal] = useState({
+    isOpen: false,
+    selectedId: null,
+  });
+
   // API Data Fetching with diff and setPointId
   const fetchData = async (diff, targetPage) => {
     setLoading(true);
@@ -197,7 +204,23 @@ const Kiralama = () => {
   };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    // Open DetailUpdate modal with the vehicle's aracId
+    setDetailUpdateModal({
+      isOpen: true,
+      selectedId: record.aracId,
+    });
+  };
+
+  const handleDetailUpdateClose = () => {
+    setDetailUpdateModal({
+      isOpen: false,
+      selectedId: null,
+    });
+  };
+
+  const handleDetailUpdateSuccess = () => {
+    // Refresh table data after successful update
+    refreshTableData();
   };
 
   const refreshTableData = useCallback(() => {
@@ -509,6 +532,15 @@ const Kiralama = () => {
 
   return (
     <>
+      {/* DetailUpdate Modal */}
+      <DetailUpdate
+        isOpen={detailUpdateModal.isOpen}
+        onClose={handleDetailUpdateClose}
+        selectedId={detailUpdateModal.selectedId}
+        onSuccess={handleDetailUpdateSuccess}
+        selectedRows1={selectedRows}
+      />
+
       {/* Modal for managing columns */}
       <Modal title="Sütunları Yönet" centered width={800} open={isModalVisible} onOk={() => setIsModalVisible(false)} onCancel={() => setIsModalVisible(false)}>
         <Text style={{ marginBottom: "15px" }}>Aşağıdaki Ekranlardan Sütunları Göster / Gizle ve Sıralamalarını Ayarlayabilirsiniz.</Text>

--- a/src/_root/components/Hatirlatici/components/Muayene.jsx
+++ b/src/_root/components/Hatirlatici/components/Muayene.jsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { t } from "i18next";
+import DetailUpdate from "../../../pages/vehicles-control/vehicle-detail/DetailUpdate";
 
 const { Text } = Typography;
 
@@ -126,6 +127,12 @@ const Muayene = () => {
 
   const [selectedRows, setSelectedRows] = useState([]);
 
+  // DetailUpdate modal state
+  const [detailUpdateModal, setDetailUpdateModal] = useState({
+    isOpen: false,
+    selectedId: null,
+  });
+
   // API Data Fetching with diff and setPointId
   const fetchData = async (diff, targetPage) => {
     setLoading(true);
@@ -169,7 +176,6 @@ const Muayene = () => {
 
   useEffect(() => {
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Search handling
@@ -198,14 +204,29 @@ const Muayene = () => {
   };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    // Open DetailUpdate modal with the vehicle's aracId
+    setDetailUpdateModal({
+      isOpen: true,
+      selectedId: record.aracId,
+    });
+  };
+
+  const handleDetailUpdateClose = () => {
+    setDetailUpdateModal({
+      isOpen: false,
+      selectedId: null,
+    });
+  };
+
+  const handleDetailUpdateSuccess = () => {
+    // Refresh table data after successful update
+    refreshTableData();
   };
 
   const refreshTableData = useCallback(() => {
     setSelectedRowKeys([]);
     setSelectedRows([]);
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Columns definition (adjust as needed)
@@ -511,6 +532,15 @@ const Muayene = () => {
 
   return (
     <>
+      {/* DetailUpdate Modal */}
+      <DetailUpdate
+        isOpen={detailUpdateModal.isOpen}
+        onClose={handleDetailUpdateClose}
+        selectedId={detailUpdateModal.selectedId}
+        onSuccess={handleDetailUpdateSuccess}
+        selectedRows1={selectedRows}
+      />
+
       {/* Modal for managing columns */}
       <Modal title="Sütunları Yönet" centered width={800} open={isModalVisible} onOk={() => setIsModalVisible(false)} onCancel={() => setIsModalVisible(false)}>
         <Text style={{ marginBottom: "15px" }}>Aşağıdaki Ekranlardan Sütunları Göster / Gizle ve Sıralamalarını Ayarlayabilirsiniz.</Text>

--- a/src/_root/components/Hatirlatici/components/Sozlesme.jsx
+++ b/src/_root/components/Hatirlatici/components/Sozlesme.jsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { t } from "i18next";
+import DetailUpdate from "../../../pages/vehicles-control/vehicle-detail/DetailUpdate";
 
 const { Text } = Typography;
 
@@ -126,6 +127,12 @@ const Sozlesme = () => {
 
   const [selectedRows, setSelectedRows] = useState([]);
 
+  // DetailUpdate modal state
+  const [detailUpdateModal, setDetailUpdateModal] = useState({
+    isOpen: false,
+    selectedId: null,
+  });
+
   // API Data Fetching with diff and setPointId
   const fetchData = async (diff, targetPage) => {
     setLoading(true);
@@ -169,7 +176,6 @@ const Sozlesme = () => {
 
   useEffect(() => {
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Search handling
@@ -198,14 +204,29 @@ const Sozlesme = () => {
   };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    // Open DetailUpdate modal with the vehicle's aracId
+    setDetailUpdateModal({
+      isOpen: true,
+      selectedId: record.aracId,
+    });
+  };
+
+  const handleDetailUpdateClose = () => {
+    setDetailUpdateModal({
+      isOpen: false,
+      selectedId: null,
+    });
+  };
+
+  const handleDetailUpdateSuccess = () => {
+    // Refresh table data after successful update
+    refreshTableData();
   };
 
   const refreshTableData = useCallback(() => {
     setSelectedRowKeys([]);
     setSelectedRows([]);
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Columns definition (adjust as needed)
@@ -511,6 +532,15 @@ const Sozlesme = () => {
 
   return (
     <>
+      {/* DetailUpdate Modal */}
+      <DetailUpdate
+        isOpen={detailUpdateModal.isOpen}
+        onClose={handleDetailUpdateClose}
+        selectedId={detailUpdateModal.selectedId}
+        onSuccess={handleDetailUpdateSuccess}
+        selectedRows1={selectedRows}
+      />
+
       {/* Modal for managing columns */}
       <Modal title="Sütunları Yönet" centered width={800} open={isModalVisible} onOk={() => setIsModalVisible(false)} onCancel={() => setIsModalVisible(false)}>
         <Text style={{ marginBottom: "15px" }}>Aşağıdaki Ekranlardan Sütunları Göster / Gizle ve Sıralamalarını Ayarlayabilirsiniz.</Text>

--- a/src/_root/components/Hatirlatici/components/Takograf.jsx
+++ b/src/_root/components/Hatirlatici/components/Takograf.jsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { t } from "i18next";
+import DetailUpdate from "../../../pages/vehicles-control/vehicle-detail/DetailUpdate";
 
 const { Text } = Typography;
 
@@ -126,6 +127,12 @@ const Takograf = () => {
 
   const [selectedRows, setSelectedRows] = useState([]);
 
+  // DetailUpdate modal state
+  const [detailUpdateModal, setDetailUpdateModal] = useState({
+    isOpen: false,
+    selectedId: null,
+  });
+
   // API Data Fetching with diff and setPointId
   const fetchData = async (diff, targetPage) => {
     setLoading(true);
@@ -197,7 +204,23 @@ const Takograf = () => {
   };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    // Open DetailUpdate modal with the vehicle's aracId
+    setDetailUpdateModal({
+      isOpen: true,
+      selectedId: record.aracId,
+    });
+  };
+
+  const handleDetailUpdateClose = () => {
+    setDetailUpdateModal({
+      isOpen: false,
+      selectedId: null,
+    });
+  };
+
+  const handleDetailUpdateSuccess = () => {
+    // Refresh table data after successful update
+    refreshTableData();
   };
 
   const refreshTableData = useCallback(() => {
@@ -468,6 +491,15 @@ const Takograf = () => {
 
   return (
     <>
+      {/* DetailUpdate Modal */}
+      <DetailUpdate
+        isOpen={detailUpdateModal.isOpen}
+        onClose={handleDetailUpdateClose}
+        selectedId={detailUpdateModal.selectedId}
+        onSuccess={handleDetailUpdateSuccess}
+        selectedRows1={selectedRows}
+      />
+
       {/* Modal for managing columns */}
       <Modal title="Sütunları Yönet" centered width={800} open={isModalVisible} onOk={() => setIsModalVisible(false)} onCancel={() => setIsModalVisible(false)}>
         <Text style={{ marginBottom: "15px" }}>Aşağıdaki Ekranlardan Sütunları Göster / Gizle ve Sıralamalarını Ayarlayabilirsiniz.</Text>

--- a/src/_root/components/Hatirlatici/components/TasitKarti.jsx
+++ b/src/_root/components/Hatirlatici/components/TasitKarti.jsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { t } from "i18next";
+import DetailUpdate from "../../../pages/vehicles-control/vehicle-detail/DetailUpdate";
 
 const { Text } = Typography;
 
@@ -126,6 +127,12 @@ const TasitKarti = () => {
 
   const [selectedRows, setSelectedRows] = useState([]);
 
+  // DetailUpdate modal state
+  const [detailUpdateModal, setDetailUpdateModal] = useState({
+    isOpen: false,
+    selectedId: null,
+  });
+
   // API Data Fetching with diff and setPointId
   const fetchData = async (diff, targetPage) => {
     setLoading(true);
@@ -169,7 +176,6 @@ const TasitKarti = () => {
 
   useEffect(() => {
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Search handling
@@ -198,14 +204,29 @@ const TasitKarti = () => {
   };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    // Open DetailUpdate modal with the vehicle's aracId
+    setDetailUpdateModal({
+      isOpen: true,
+      selectedId: record.aracId,
+    });
+  };
+
+  const handleDetailUpdateClose = () => {
+    setDetailUpdateModal({
+      isOpen: false,
+      selectedId: null,
+    });
+  };
+
+  const handleDetailUpdateSuccess = () => {
+    // Refresh table data after successful update
+    refreshTableData();
   };
 
   const refreshTableData = useCallback(() => {
     setSelectedRowKeys([]);
     setSelectedRows([]);
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Columns definition (adjust as needed)
@@ -481,6 +502,15 @@ const TasitKarti = () => {
 
   return (
     <>
+      {/* DetailUpdate Modal */}
+      <DetailUpdate
+        isOpen={detailUpdateModal.isOpen}
+        onClose={handleDetailUpdateClose}
+        selectedId={detailUpdateModal.selectedId}
+        onSuccess={handleDetailUpdateSuccess}
+        selectedRows1={selectedRows}
+      />
+
       {/* Modal for managing columns */}
       <Modal title="Sütunları Yönet" centered width={800} open={isModalVisible} onOk={() => setIsModalVisible(false)} onCancel={() => setIsModalVisible(false)}>
         <Text style={{ marginBottom: "15px" }}>Aşağıdaki Ekranlardan Sütunları Göster / Gizle ve Sıralamalarını Ayarlayabilirsiniz.</Text>

--- a/src/_root/components/Hatirlatici/components/Vergi.jsx
+++ b/src/_root/components/Hatirlatici/components/Vergi.jsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { t } from "i18next";
+import DetailUpdate from "../../../pages/vehicles-control/vehicle-detail/DetailUpdate";
 
 const { Text } = Typography;
 
@@ -126,6 +127,12 @@ const Vergi = () => {
 
   const [selectedRows, setSelectedRows] = useState([]);
 
+  // DetailUpdate modal state
+  const [detailUpdateModal, setDetailUpdateModal] = useState({
+    isOpen: false,
+    selectedId: null,
+  });
+
   // API Data Fetching with diff and setPointId
   const fetchData = async (diff, targetPage) => {
     setLoading(true);
@@ -169,7 +176,6 @@ const Vergi = () => {
 
   useEffect(() => {
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Search handling
@@ -198,14 +204,29 @@ const Vergi = () => {
   };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    // Open DetailUpdate modal with the vehicle's aracId
+    setDetailUpdateModal({
+      isOpen: true,
+      selectedId: record.aracId,
+    });
+  };
+
+  const handleDetailUpdateClose = () => {
+    setDetailUpdateModal({
+      isOpen: false,
+      selectedId: null,
+    });
+  };
+
+  const handleDetailUpdateSuccess = () => {
+    // Refresh table data after successful update
+    refreshTableData();
   };
 
   const refreshTableData = useCallback(() => {
     setSelectedRowKeys([]);
     setSelectedRows([]);
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Columns definition (adjust as needed)
@@ -511,6 +532,15 @@ const Vergi = () => {
 
   return (
     <>
+      {/* DetailUpdate Modal */}
+      <DetailUpdate
+        isOpen={detailUpdateModal.isOpen}
+        onClose={handleDetailUpdateClose}
+        selectedId={detailUpdateModal.selectedId}
+        onSuccess={handleDetailUpdateSuccess}
+        selectedRows1={selectedRows}
+      />
+
       {/* Modal for managing columns */}
       <Modal title="Sütunları Yönet" centered width={800} open={isModalVisible} onOk={() => setIsModalVisible(false)} onCancel={() => setIsModalVisible(false)}>
         <Text style={{ marginBottom: "15px" }}>Aşağıdaki Ekranlardan Sütunları Göster / Gizle ve Sıralamalarını Ayarlayabilirsiniz.</Text>

--- a/src/_root/components/Hatirlatici/components/YakitTuketimi.jsx
+++ b/src/_root/components/Hatirlatici/components/YakitTuketimi.jsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { t } from "i18next";
+import DetailUpdate from "../../../pages/vehicles-control/vehicle-detail/DetailUpdate";
 
 const { Text } = Typography;
 
@@ -126,6 +127,12 @@ const YakitTuketimi = () => {
 
   const [selectedRows, setSelectedRows] = useState([]);
 
+  // DetailUpdate modal state
+  const [detailUpdateModal, setDetailUpdateModal] = useState({
+    isOpen: false,
+    selectedId: null,
+  });
+
   // API Data Fetching with diff and setPointId
   const fetchData = async (diff, targetPage) => {
     setLoading(true);
@@ -197,7 +204,23 @@ const YakitTuketimi = () => {
   };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    // Open DetailUpdate modal with the vehicle's aracId
+    setDetailUpdateModal({
+      isOpen: true,
+      selectedId: record.aracId,
+    });
+  };
+
+  const handleDetailUpdateClose = () => {
+    setDetailUpdateModal({
+      isOpen: false,
+      selectedId: null,
+    });
+  };
+
+  const handleDetailUpdateSuccess = () => {
+    // Refresh table data after successful update
+    refreshTableData();
   };
 
   const refreshTableData = useCallback(() => {
@@ -490,6 +513,15 @@ const YakitTuketimi = () => {
 
   return (
     <>
+      {/* DetailUpdate Modal */}
+      <DetailUpdate
+        isOpen={detailUpdateModal.isOpen}
+        onClose={handleDetailUpdateClose}
+        selectedId={detailUpdateModal.selectedId}
+        onSuccess={handleDetailUpdateSuccess}
+        selectedRows1={selectedRows}
+      />
+
       {/* Modal for managing columns */}
       <Modal title="Sütunları Yönet" centered width={800} open={isModalVisible} onOk={() => setIsModalVisible(false)} onCancel={() => setIsModalVisible(false)}>
         <Text style={{ marginBottom: "15px" }}>Aşağıdaki Ekranlardan Sütunları Göster / Gizle ve Sıralamalarını Ayarlayabilirsiniz.</Text>


### PR DESCRIPTION
Integrated the DetailUpdate modal into all Hatirlatici subcomponents (Egzoz, Kiralama, Muayene, Sozlesme, Takograf, TasitKarti, Vergi, YakitTuketimi). Clicking a row now opens the DetailUpdate modal for the selected vehicle, and table data refreshes after a successful update. Also updated .gitignore to include project-structure.md.