### PR TITLE
Add update modals to reminder components

### DIFF
--- a/src/_root/components/Hatirlatici/components/CezaOdeme.jsx
+++ b/src/_root/components/Hatirlatici/components/CezaOdeme.jsx
@@ -1,17 +1,16 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Table, Button, Modal, Checkbox, Input, Spin, Typography, Tag, message, Tooltip } from "antd";
-import { HolderOutlined, SearchOutlined, MenuOutlined, HomeOutlined, ArrowDownOutlined, ArrowUpOutlined, CheckOutlined, CloseOutlined } from "@ant-design/icons";
+import { Table, Button, Modal, Checkbox, Input, Spin, Typography, message } from "antd";
+import { HolderOutlined, SearchOutlined, MenuOutlined } from "@ant-design/icons";
 import { DndContext, useSensor, useSensors, PointerSensor, KeyboardSensor } from "@dnd-kit/core";
 import { sortableKeyboardCoordinates, arrayMove, useSortable, SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Resizable } from "react-resizable";
 import "./ResizeStyle.css";
 import AxiosInstance from "../../../../api/http";
-import { useFormContext } from "react-hook-form";
 import styled from "styled-components";
-import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { t } from "i18next";
+import UpdateModal from "../../../pages/vehicles-control/ceza/UpdateModal";
 
 const { Text } = Typography;
 
@@ -114,14 +113,10 @@ const CezaOdeme = () => {
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
   const [loading, setLoading] = useState(false); // Set initial loading state to false
   const [searchTerm, setSearchTerm] = useState("");
-  const [searchTimeout, setSearchTimeout] = useState(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalCount, setTotalCount] = useState(0); // Total data count
-  const [pageSize, setPageSize] = useState(10); // Page size
-  const [drawer, setDrawer] = useState({
-    visible: false,
-    data: null,
-  });
+  const [drawerVisible, setDrawerVisible] = useState(false);
+  const [selectedRow, setSelectedRow] = useState(null);
   const navigate = useNavigate();
 
   const [selectedRows, setSelectedRows] = useState([]);
@@ -197,7 +192,8 @@ const CezaOdeme = () => {
   };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    setSelectedRow(record);
+    setDrawerVisible(true);
   };
 
   const refreshTableData = useCallback(() => {
@@ -298,47 +294,6 @@ const CezaOdeme = () => {
       day: "2-digit",
     });
     return formatter.format(new Date(date));
-  };
-
-  const formatTime = (time) => {
-    if (!time || time.trim() === "") return ""; // `trim` metodu ile baştaki ve sondaki boşlukları temizle
-
-    try {
-      // Saati ve dakikayı parçalara ayır, boşlukları temizle
-      const [hours, minutes] = time
-        .trim()
-        .split(":")
-        .map((part) => part.trim());
-
-      // Saat ve dakika değerlerinin geçerliliğini kontrol et
-      const hoursInt = parseInt(hours, 10);
-      const minutesInt = parseInt(minutes, 10);
-      if (isNaN(hoursInt) || isNaN(minutesInt) || hoursInt < 0 || hoursInt > 23 || minutesInt < 0 || minutesInt > 59) {
-        // throw new Error("Invalid time format"); // hata fırlatır ve uygulamanın çalışmasını durdurur
-        console.error("Invalid time format:", time);
-        // return time; // Hatalı formatı olduğu gibi döndür
-        return ""; // Hata durumunda boş bir string döndür
-      }
-
-      // Geçerli tarih ile birlikte bir Date nesnesi oluştur ve sadece saat ve dakika bilgilerini ayarla
-      const date = new Date();
-      date.setHours(hoursInt, minutesInt, 0);
-
-      // Kullanıcının lokal ayarlarına uygun olarak saat ve dakikayı formatla
-      // `hour12` seçeneğini belirtmeyerek Intl.DateTimeFormat'ın kullanıcının yerel ayarlarına göre otomatik seçim yapmasına izin ver
-      const formatter = new Intl.DateTimeFormat(navigator.language, {
-        hour: "numeric",
-        minute: "2-digit",
-        // hour12 seçeneği burada belirtilmiyor; böylece otomatik olarak kullanıcının sistem ayarlarına göre belirleniyor
-      });
-
-      // Formatlanmış saati döndür
-      return formatter.format(date);
-    } catch (error) {
-      console.error("Error formatting time:", error);
-      return ""; // Hata durumunda boş bir string döndür
-      // return time; // Hatalı formatı olduğu gibi döndür
-    }
   };
 
   // tarihleri kullanıcının local ayarlarına bakarak formatlayıp ekrana o şekilde yazdırmak için sonu
@@ -605,6 +560,18 @@ const CezaOdeme = () => {
           scroll={{ y: "calc(100vh - 335px)" }}
         />
       </Spin>
+
+      {/* UpdateModal */}
+      <UpdateModal
+        drawerVisible={drawerVisible}
+        onDrawerClose={() => {
+          setDrawerVisible(false);
+          setSelectedRow(null);
+        }}
+        selectedRow={selectedRow}
+        onRefresh={refreshTableData}
+        setStatus={() => {}}
+      />
     </>
   );
 };

--- a/src/_root/components/Hatirlatici/components/PeriyodikBakim.jsx
+++ b/src/_root/components/Hatirlatici/components/PeriyodikBakim.jsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { t } from "i18next";
+import EditDrawer from "../../../pages/BakimVeOnarim/PeriyodikBakimlar/Update/EditDrawer";
 
 const { Text } = Typography;
 
@@ -125,6 +126,8 @@ const PeriyodikBakim = () => {
   const navigate = useNavigate();
 
   const [selectedRows, setSelectedRows] = useState([]);
+  const [editDrawerVisible, setEditDrawerVisible] = useState(false);
+  const [selectedRowForEdit, setSelectedRowForEdit] = useState(null);
 
   // API Data Fetching with diff and setPointId
   const fetchData = async (diff, targetPage) => {
@@ -169,7 +172,6 @@ const PeriyodikBakim = () => {
 
   useEffect(() => {
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Search handling
@@ -198,14 +200,23 @@ const PeriyodikBakim = () => {
   };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    setSelectedRowForEdit(record);
+    setEditDrawerVisible(true);
+  };
+
+  const handleEditDrawerClose = () => {
+    setEditDrawerVisible(false);
+    setSelectedRowForEdit(null);
+  };
+
+  const handleRefresh = () => {
+    refreshTableData();
   };
 
   const refreshTableData = useCallback(() => {
     setSelectedRowKeys([]);
     setSelectedRows([]);
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Columns definition (adjust as needed)
@@ -699,6 +710,8 @@ const PeriyodikBakim = () => {
           scroll={{ y: "calc(100vh - 335px)" }}
         />
       </Spin>
+
+      <EditDrawer selectedRow={selectedRowForEdit} onDrawerClose={handleEditDrawerClose} drawerVisible={editDrawerVisible} onRefresh={handleRefresh} />
     </>
   );
 };

--- a/src/_root/components/Hatirlatici/components/Sigorta.jsx
+++ b/src/_root/components/Hatirlatici/components/Sigorta.jsx
@@ -10,6 +10,8 @@ import AxiosInstance from "../../../../api/http";
 import { useFormContext } from "react-hook-form";
 import styled from "styled-components";
 import dayjs from "dayjs";
+import UpdateModal from "../../../pages/vehicles-control/sigorta/UpdateModal";
+import { PlakaProvider } from "../../../../context/plakaSlice";
 
 const { Text } = Typography;
 
@@ -141,6 +143,10 @@ const Sigorta = () => {
   // edit drawer için son
 
   const [selectedRows, setSelectedRows] = useState([]);
+
+  // UpdateModal için state'ler
+  const [updateModalVisible, setUpdateModalVisible] = useState(false);
+  const [selectedRowForUpdate, setSelectedRowForUpdate] = useState(null);
 
   function hexToRGBA(hex, opacity) {
     // hex veya opacity null ise hata döndür
@@ -572,7 +578,8 @@ const Sigorta = () => {
   // };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    setSelectedRowForUpdate(record);
+    setUpdateModalVisible(true);
   };
 
   const refreshTableData = useCallback(() => {
@@ -871,6 +878,24 @@ const Sigorta = () => {
           rowClassName={(record) => (record.IST_DURUM_ID === 0 ? "boldRow" : "")}
         />
       </Spin>
+
+      {/* UpdateModal bileşeni */}
+      <PlakaProvider>
+        <UpdateModal
+          updateModal={updateModalVisible}
+          setUpdateModal={setUpdateModalVisible}
+          id={selectedRowForUpdate?.siraNo}
+          setStatus={() => {}}
+          selectedRow={selectedRowForUpdate ? { ...selectedRowForUpdate, key: selectedRowForUpdate.siraNo } : null}
+          onDrawerClose={() => {
+            setUpdateModalVisible(false);
+            setSelectedRowForUpdate(null);
+            refreshTableData();
+          }}
+          drawerVisible={updateModalVisible}
+          onRefresh={refreshTableData}
+        />
+      </PlakaProvider>
     </>
   );
 };

--- a/src/_root/components/Hatirlatici/components/Stok.jsx
+++ b/src/_root/components/Hatirlatici/components/Stok.jsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { t } from "i18next";
+import UpdateModal from "../../../pages/malzeme-depo/malzeme/UpdateModal";
 
 const { Text } = Typography;
 
@@ -126,6 +127,10 @@ const Stok = () => {
 
   const [selectedRows, setSelectedRows] = useState([]);
 
+  // UpdateModal için state'ler
+  const [updateModalVisible, setUpdateModalVisible] = useState(false);
+  const [selectedMaterial, setSelectedMaterial] = useState(null);
+
   // API Data Fetching with diff and setPointId
   const fetchData = async (diff, targetPage) => {
     setLoading(true);
@@ -169,7 +174,6 @@ const Stok = () => {
 
   useEffect(() => {
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Search handling
@@ -198,14 +202,20 @@ const Stok = () => {
   };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    setSelectedMaterial(record);
+    setUpdateModalVisible(true);
+  };
+
+  const handleUpdateModalClose = () => {
+    setUpdateModalVisible(false);
+    setSelectedMaterial(null);
+    refreshTableData();
   };
 
   const refreshTableData = useCallback(() => {
     setSelectedRowKeys([]);
     setSelectedRows([]);
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Columns definition (adjust as needed)
@@ -546,6 +556,9 @@ const Stok = () => {
           </DndContext>
         </div>
       </Modal>
+
+      {/* UpdateModal */}
+      {selectedMaterial && <UpdateModal selectedRow={selectedMaterial} drawerVisible={updateModalVisible} onDrawerClose={handleUpdateModalClose} onRefresh={refreshTableData} />}
 
       {/* Toolbar */}
       <div

--- a/src/_root/components/Hatirlatici/components/Surucu.jsx
+++ b/src/_root/components/Hatirlatici/components/Surucu.jsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { t } from "i18next";
+import UpdateModal from "../../../pages/sistem-tanimlari/surucu/UpdateModal";
 
 const { Text } = Typography;
 
@@ -125,6 +126,8 @@ const Surucu = () => {
   const navigate = useNavigate();
 
   const [selectedRows, setSelectedRows] = useState([]);
+  const [updateModalVisible, setUpdateModalVisible] = useState(false);
+  const [selectedDriver, setSelectedDriver] = useState(null);
 
   // API Data Fetching with diff and setPointId
   const fetchData = async (diff, targetPage) => {
@@ -169,7 +172,6 @@ const Surucu = () => {
 
   useEffect(() => {
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Search handling
@@ -198,14 +200,20 @@ const Surucu = () => {
   };
 
   const onRowClick = (record) => {
-    setDrawer({ visible: true, data: record });
+    setSelectedDriver(record);
+    setUpdateModalVisible(true);
+  };
+
+  const handleUpdateModalClose = () => {
+    setUpdateModalVisible(false);
+    setSelectedDriver(null);
+    refreshTableData(); // Tabloyu yenile
   };
 
   const refreshTableData = useCallback(() => {
     setSelectedRowKeys([]);
     setSelectedRows([]);
     fetchData(0, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Columns definition (adjust as needed)
@@ -367,9 +375,9 @@ const Surucu = () => {
 
   // Manage columns from localStorage or default
   const [columns, setColumns] = useState(() => {
-    const savedOrder = localStorage.getItem("columnOrderSurucu");
-    const savedVisibility = localStorage.getItem("columnVisibilitySurucu");
-    const savedWidths = localStorage.getItem("columnWidthsSurucu");
+    const savedOrder = localStorage.getItem("columnOrderSurucuHatirlatici");
+    const savedVisibility = localStorage.getItem("columnVisibilitySurucuHatirlatici");
+    const savedWidths = localStorage.getItem("columnWidthsSurucuHatirlatici");
 
     let order = savedOrder ? JSON.parse(savedOrder) : [];
     let visibility = savedVisibility ? JSON.parse(savedVisibility) : {};
@@ -387,9 +395,9 @@ const Surucu = () => {
       }
     });
 
-    localStorage.setItem("columnOrderSurucu", JSON.stringify(order));
-    localStorage.setItem("columnVisibilitySurucu", JSON.stringify(visibility));
-    localStorage.setItem("columnWidthsSurucu", JSON.stringify(widths));
+    localStorage.setItem("columnOrderSurucuHatirlatici", JSON.stringify(order));
+    localStorage.setItem("columnVisibilitySurucuHatirlatici", JSON.stringify(visibility));
+    localStorage.setItem("columnWidthsSurucuHatirlatici", JSON.stringify(widths));
 
     return order.map((key) => {
       const column = initialColumns.find((col) => col.key === key);
@@ -399,9 +407,9 @@ const Surucu = () => {
 
   // Save columns to localStorage
   useEffect(() => {
-    localStorage.setItem("columnOrderSurucu", JSON.stringify(columns.map((col) => col.key)));
+    localStorage.setItem("columnOrderSurucuHatirlatici", JSON.stringify(columns.map((col) => col.key)));
     localStorage.setItem(
-      "columnVisibilitySurucu",
+      "columnVisibilitySurucuHatirlatici",
       JSON.stringify(
         columns.reduce(
           (acc, col) => ({
@@ -413,7 +421,7 @@ const Surucu = () => {
       )
     );
     localStorage.setItem(
-      "columnWidthsSurucu",
+      "columnWidthsSurucuHatirlatici",
       JSON.stringify(
         columns.reduce(
           (acc, col) => ({
@@ -478,9 +486,9 @@ const Surucu = () => {
 
   // Reset columns
   const resetColumns = () => {
-    localStorage.removeItem("columnOrderSurucu");
-    localStorage.removeItem("columnVisibilitySurucu");
-    localStorage.removeItem("columnWidthsSurucu");
+    localStorage.removeItem("columnOrderSurucuHatirlatici");
+    localStorage.removeItem("columnVisibilitySurucuHatirlatici");
+    localStorage.removeItem("columnWidthsSurucuHatirlatici");
     window.location.reload();
   };
 
@@ -569,6 +577,20 @@ const Surucu = () => {
           </DndContext>
         </div>
       </Modal>
+
+      {/* UpdateModal */}
+      {selectedDriver && (
+        <UpdateModal
+          updateModal={updateModalVisible}
+          setUpdateModal={setUpdateModalVisible}
+          setStatus={() => {}}
+          id={selectedDriver.surucuId}
+          selectedRow={selectedDriver}
+          onDrawerClose={handleUpdateModalClose}
+          drawerVisible={updateModalVisible}
+          onRefresh={refreshTableData}
+        />
+      )}
 
       {/* Toolbar */}
       <div

--- a/src/_root/pages/vehicles-control/ceza/UpdateModal.jsx
+++ b/src/_root/pages/vehicles-control/ceza/UpdateModal.jsx
@@ -295,6 +295,10 @@ UpdateModal.propTypes = {
   setUpdateModal: PropTypes.func,
   setStatus: PropTypes.func,
   id: PropTypes.number,
+  selectedRow: PropTypes.object,
+  onDrawerClose: PropTypes.func,
+  drawerVisible: PropTypes.bool,
+  onRefresh: PropTypes.func,
 };
 
 export default UpdateModal;

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -1170,7 +1170,7 @@
   "hasarBoyutu": "Hasar Boyutu",
   "olayYeri": "Olay Yeri",
   "hasarliBolge": "Hasarlı Bölge",
-  "": "",
+  "srcPiskotektinkBitisTarihi": "Psikoteknik Bitiş Tarihi",
   "": "",
   "": "",
   "": "",


### PR DESCRIPTION
Integrated UpdateModal or EditDrawer components into CezaOdeme, PeriyodikBakim, Sigorta, Stok, and Surucu reminder components for editing records via modals or drawers. Updated state management and row click handlers to support opening these modals. Adjusted localStorage keys for Surucu columns and added a missing translation key for 'Psikoteknik Bitiş Tarihi'.