### PR TITLE
Change company list fetch from GET to POST request

### DIFF
--- a/src/_root/pages/sistem-tanimlari/firma-tanim/FirmaTanim.jsx
+++ b/src/_root/pages/sistem-tanimlari/firma-tanim/FirmaTanim.jsx
@@ -145,7 +145,7 @@ const Yakit = () => {
         currentSetPointId = 0;
       }
 
-      const response = await AxiosInstance.get(`Company/GetCompaniesList?diff=${diff}&setPointId=${currentSetPointId}&parameter=${searchTerm}`);
+      const response = await AxiosInstance.post(`Company/GetCompaniesList?diff=${diff}&setPointId=${currentSetPointId}&parameter=${searchTerm}`);
 
       const total = response.data.recordCount;
       setTotalCount(total);


### PR DESCRIPTION
Updated the API call in FirmaTanim.jsx to use AxiosInstance.post instead of get when fetching the company list. This may be required for backend compatibility or to support sending larger payloads.