### PR TITLE
Set default status filter to 'active' in FirmaTanim

### DIFF
--- a/src/_root/pages/sistem-tanimlari/firma-tanim/FirmaTanim.jsx
+++ b/src/_root/pages/sistem-tanimlari/firma-tanim/FirmaTanim.jsx
@@ -125,7 +125,7 @@ const Yakit = () => {
     visible: false,
     data: null,
   });
-  const [statusFilter, setStatusFilter] = useState("all"); // Status filter state
+  const [statusFilter, setStatusFilter] = useState("active"); // Status filter state
   const navigate = useNavigate();
 
   const [selectedRows, setSelectedRows] = useState([]);


### PR DESCRIPTION
Changed the initial value of the statusFilter state from 'all' to 'active' in the FirmaTanim component to display only active items by default.