### PR TITLE
Switch to rollup-plugin-visualizer for bundle analysis

### DIFF
--- a/PERFORMANCE_OPTIMIZATION.md
+++ b/PERFORMANCE_OPTIMIZATION.md
@@ -188,7 +188,7 @@ npm run test:coverage
 - Service Worker sadece HTTPS'de çalışır
 - Cache temizleme için `clearCache()` fonksiyonunu kullanın
 - Performance hook'u sadece development'ta çalışır
-- Bundle analizi için `vite-plugin-analyzer` kullanın
+- Bundle analizi için `rollup-plugin-visualizer` kullanın
 
 ## 🎯 Sonraki Adımlar
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "prettier": "^3.5.0",
     "prettier-eslint": "^16.3.0",
     "vite": "^6.1.0",
-    "vite-plugin-analyzer": "^0.5.0",
+    "rollup-plugin-visualizer": "^5.12.0",
     "vitest": "^1.0.0",
     "@vitest/coverage-v8": "^1.0.0"
   }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,36 +1,53 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { visualizer } from "rollup-plugin-visualizer";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    host: true,
-    port: 5174,
-  },
-  build: {
-    commonjsOptions: {
-      transformMixedEsModules: true,
+export default defineConfig(({ mode }) => {
+  const plugins = [react()];
+
+  // Bundle analyzer sadece analyze modunda
+  if (mode === "analyze") {
+    plugins.push(
+      visualizer({
+        filename: "dist/stats.html",
+        open: true,
+        gzipSize: true,
+        brotliSize: true,
+      })
+    );
+  }
+
+  return {
+    plugins,
+    server: {
+      host: true,
+      port: 5174,
     },
-    // Build optimizasyonları
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          // Vendor chunk'ları ayır
-          vendor: ["react", "react-dom", "react-router-dom"],
-          antd: ["antd"],
-          charts: ["recharts"],
-          utils: ["lodash", "dayjs", "axios"],
+    build: {
+      commonjsOptions: {
+        transformMixedEsModules: true,
+      },
+      // Build optimizasyonları
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            // Vendor chunk'ları ayır
+            vendor: ["react", "react-dom", "react-router-dom"],
+            antd: ["antd"],
+            charts: ["recharts"],
+            utils: ["lodash", "dayjs", "axios"],
+          },
         },
       },
+      // Chunk boyutu uyarısını artır
+      chunkSizeWarningLimit: 1000,
+      // Source map'i production'da kapat
+      sourcemap: false,
     },
-    // Chunk boyutu uyarısını artır
-    chunkSizeWarningLimit: 1000,
-    // Source map'i production'da kapat
-    sourcemap: false,
-  },
-  // Pre-bundle optimizasyonu
-  optimizeDeps: {
-    include: ["react", "react-dom", "react-router-dom", "antd", "lodash", "dayjs", "axios"],
-  },
+    // Pre-bundle optimizasyonu
+    optimizeDeps: {
+      include: ["react", "react-dom", "react-router-dom", "antd", "lodash", "dayjs", "axios"],
+    },
+  };
 });


### PR DESCRIPTION
Replaced vite-plugin-analyzer with rollup-plugin-visualizer for bundle analysis. Updated documentation, dependencies, and Vite config to enable visualizer only in analyze mode.