### PR TITLE
Comment out lokasyonId assignment in DetailUpdate

### DIFF
--- a/src/_root/pages/vehicles-control/vehicle-detail/DetailUpdate.jsx
+++ b/src/_root/pages/vehicles-control/vehicle-detail/DetailUpdate.jsx
@@ -377,7 +377,7 @@ const DetailUpdate = ({ isOpen, onClose, selectedId, onSuccess, selectedRows1 })
       aracGrubuId: values.aracGrubuID || 0,
       aracRenkId: values.renkID || 0,
       AracCinsiKodId: values.aracCinsiKodId || 0,
-      lokasyonId: values.lokasyonId || 0,
+      /* lokasyonId: values.lokasyonId || 0, */
       departmanId: values.departmanID || 0,
       surucuId: values.surucuId || 0,
       bagliAracId: values.bagliAracId || 0,


### PR DESCRIPTION
The assignment of lokasyonId in the payload object has been commented out, possibly to prevent sending this field during updates or due to changes in backend requirements.