### PR TITLE
Update user color handling in CreateDrawer component

### DIFF
--- a/src/_root/pages/SistemAyarlari/KullaniciTanimlari/Insert/CreateDrawer.jsx
+++ b/src/_root/pages/SistemAyarlari/KullaniciTanimlari/Insert/CreateDrawer.jsx
@@ -71,7 +71,7 @@ export default function CreateModal({ selectedLokasyonId, onRefresh }) {
       email: data.mail,
       telefon: data.telefonNo,
       paraf: data.paraf,
-      kullaniciRengi: data.color.toHexString(),
+      kullaniciRengi: data.color ? (typeof data.color === "string" ? data.color : data.color.toHexString()) : "#ffffff",
     };
 
     // AxiosInstance.post("/api/endpoint", { Body }).then((response) => {


### PR DESCRIPTION
Modified the color assignment logic in CreateDrawer.jsx to ensure a default value of '#ffffff' is used when the color data is not available or is not a string. This improves robustness and prevents potential errors related to undefined color values.