### PR TITLE
Enhance ContextMenu and Sil components to support dynamic count updates

### DIFF
--- a/src/_root/pages/vehicles-control/ServisIslemleri/Update/components/SecondTabs/components/Iscilik/IscilikTablo.jsx
+++ b/src/_root/pages/vehicles-control/ServisIslemleri/Update/components/SecondTabs/components/Iscilik/IscilikTablo.jsx
@@ -207,19 +207,13 @@ export default function KontrolListesiTablo({ isActive, onCountsRefresh }) {
           <ContextMenu
             selectedRows={selectedRowsData}
             refreshTableData={refreshTable}
+            onCountsRefresh={onCountsRefresh}
             clearSelections={() => {
               setSelectedRowKeys([]);
               setSelectedRowsData([]);
             }}
           />
-          <CreateModal
-            kdvOran={watch("kdvOran")}
-            onRefresh={refreshTable}
-            onCountsRefresh={onCountsRefresh}
-            secilenKayitID={secilenKayitID}
-            plaka={plaka}
-            aracID={aracID}
-          />
+          <CreateModal kdvOran={watch("kdvOran")} onRefresh={refreshTable} onCountsRefresh={onCountsRefresh} secilenKayitID={secilenKayitID} plaka={plaka} aracID={aracID} />
         </div>
       </div>
 

--- a/src/_root/pages/vehicles-control/ServisIslemleri/Update/components/SecondTabs/components/Iscilik/components/ContextMenu/ContextMenu.jsx
+++ b/src/_root/pages/vehicles-control/ServisIslemleri/Update/components/SecondTabs/components/Iscilik/components/ContextMenu/ContextMenu.jsx
@@ -5,7 +5,7 @@ import Sil from "./components/Sil";
 
 const { Text, Link } = Typography;
 
-export default function ContextMenu({ selectedRows, refreshTableData, clearSelections }) {
+export default function ContextMenu({ selectedRows, refreshTableData, clearSelections, onCountsRefresh }) {
   const [visible, setVisible] = useState(false);
 
   const handleVisibleChange = (visible) => {
@@ -17,7 +17,11 @@ export default function ContextMenu({ selectedRows, refreshTableData, clearSelec
   };
 
   const content = (
-    <div>{selectedRows.length >= 1 && <Sil selectedRows={selectedRows} refreshTableData={refreshTableData} hidePopover={hidePopover} clearSelections={clearSelections} />}</div>
+    <div>
+      {selectedRows.length >= 1 && (
+        <Sil selectedRows={selectedRows} refreshTableData={refreshTableData} hidePopover={hidePopover} clearSelections={clearSelections} onCountsRefresh={onCountsRefresh} />
+      )}
+    </div>
   );
   return (
     <Popover placement="bottom" content={content} trigger="click" open={visible} onOpenChange={handleVisibleChange}>

--- a/src/_root/pages/vehicles-control/ServisIslemleri/Update/components/SecondTabs/components/Iscilik/components/ContextMenu/components/Sil.jsx
+++ b/src/_root/pages/vehicles-control/ServisIslemleri/Update/components/SecondTabs/components/Iscilik/components/ContextMenu/components/Sil.jsx
@@ -3,7 +3,7 @@ import AxiosInstance from "../../../../../../../../../../../../api/http";
 import { Button, message, Popconfirm } from "antd";
 import { DeleteOutlined, QuestionCircleOutlined } from "@ant-design/icons";
 
-export default function Sil({ selectedRows, refreshTableData, disabled, hidePopover, clearSelections }) {
+export default function Sil({ selectedRows, refreshTableData, disabled, hidePopover, clearSelections, onCountsRefresh }) {
   // selectedRows.forEach((row, index) => {
   //   console.log(`Satır ${index + 1} ID: ${row.key}`);
   //   // Eğer id değerleri farklı bir özellikte tutuluyorsa, row.key yerine o özelliği kullanın. Örneğin: row.id
@@ -38,6 +38,7 @@ export default function Sil({ selectedRows, refreshTableData, disabled, hidePopo
     // Tüm silme işlemleri tamamlandıktan sonra ve hata oluşmamışsa refreshTableData'i çağır
     if (!isError) {
       refreshTableData();
+      onCountsRefresh();
       hidePopover(); // Silme işlemi başarılı olursa Popover'ı kapat
 
       // Clear the selected rows after successful deletion

--- a/src/_root/pages/vehicles-control/ServisIslemleri/Update/components/SecondTabs/components/Malzemeler/Malzemeler.jsx
+++ b/src/_root/pages/vehicles-control/ServisIslemleri/Update/components/SecondTabs/components/Malzemeler/Malzemeler.jsx
@@ -224,6 +224,7 @@ export default function KontrolListesiTablo({ isActive, baslangicTarihi, onCount
         <div style={{ display: "flex", alignItems: "center" }}>
           <ContextMenu
             selectedRows={selectedRowsData}
+            onCountsRefresh={onCountsRefresh}
             refreshTableData={refreshTable}
             clearSelections={() => {
               setSelectedRowKeys([]);

--- a/src/_root/pages/vehicles-control/ServisIslemleri/Update/components/SecondTabs/components/Malzemeler/components/ContextMenu/ContextMenu.jsx
+++ b/src/_root/pages/vehicles-control/ServisIslemleri/Update/components/SecondTabs/components/Malzemeler/components/ContextMenu/ContextMenu.jsx
@@ -5,7 +5,7 @@ import Sil from "./components/Sil";
 
 const { Text, Link } = Typography;
 
-export default function ContextMenu({ selectedRows, refreshTableData, clearSelections }) {
+export default function ContextMenu({ selectedRows, refreshTableData, clearSelections, onCountsRefresh }) {
   const [visible, setVisible] = useState(false);
 
   const handleVisibleChange = (visible) => {
@@ -17,7 +17,11 @@ export default function ContextMenu({ selectedRows, refreshTableData, clearSelec
   };
 
   const content = (
-    <div>{selectedRows.length >= 1 && <Sil selectedRows={selectedRows} refreshTableData={refreshTableData} hidePopover={hidePopover} clearSelections={clearSelections} />}</div>
+    <div>
+      {selectedRows.length >= 1 && (
+        <Sil selectedRows={selectedRows} refreshTableData={refreshTableData} hidePopover={hidePopover} clearSelections={clearSelections} onCountsRefresh={onCountsRefresh} />
+      )}
+    </div>
   );
   return (
     <Popover placement="bottom" content={content} trigger="click" open={visible} onOpenChange={handleVisibleChange}>

--- a/src/_root/pages/vehicles-control/ServisIslemleri/Update/components/SecondTabs/components/Malzemeler/components/ContextMenu/components/Sil.jsx
+++ b/src/_root/pages/vehicles-control/ServisIslemleri/Update/components/SecondTabs/components/Malzemeler/components/ContextMenu/components/Sil.jsx
@@ -3,7 +3,7 @@ import AxiosInstance from "../../../../../../../../../../../../api/http";
 import { Button, message, Popconfirm } from "antd";
 import { DeleteOutlined, QuestionCircleOutlined } from "@ant-design/icons";
 
-export default function Sil({ selectedRows, refreshTableData, disabled, hidePopover, clearSelections }) {
+export default function Sil({ selectedRows, refreshTableData, disabled, hidePopover, clearSelections, onCountsRefresh }) {
   // selectedRows.forEach((row, index) => {
   //   console.log(`Satır ${index + 1} ID: ${row.key}`);
   //   // Eğer id değerleri farklı bir özellikte tutuluyorsa, row.key yerine o özelliği kullanın. Örneğin: row.id
@@ -38,6 +38,7 @@ export default function Sil({ selectedRows, refreshTableData, disabled, hidePopo
     // Tüm silme işlemleri tamamlandıktan sonra ve hata oluşmamışsa refreshTableData'i çağır
     if (!isError) {
       refreshTableData();
+      onCountsRefresh();
       hidePopover(); // Silme işlemi başarılı olursa Popover'ı kapat
 
       // Clear the selected rows after successful deletion


### PR DESCRIPTION
- Updated ContextMenu components in both Iscilik and Malzemeler sections to accept onCountsRefresh prop, enabling dynamic updates after deletion actions.
- Modified Sil components to call onCountsRefresh after successful deletion, improving data consistency and user feedback.
- Ensured adherence to ESLint rules and improved code readability throughout the changes.