### PR TITLE
Update stock table number formatting with global component

### DIFF
--- a/src/_root/pages/malzeme-depo/CikisFisleri/Table/Table.jsx
+++ b/src/_root/pages/malzeme-depo/CikisFisleri/Table/Table.jsx
@@ -23,6 +23,7 @@ import enUS from "antd/lib/locale/en_US";
 import ruRU from "antd/lib/locale/ru_RU";
 import azAZ from "antd/lib/locale/az_AZ";
 import * as XLSX from "xlsx";
+import FormattedNumber from "../../../../../hooks/FormattedNumber";
 
 const localeMap = {
   tr: trTR,
@@ -382,7 +383,7 @@ const GirisFisleri = () => {
         visible: true,
         render: (text, record) => (
           <div className="">
-            <span>{Number(text).toFixed(Number(record?.tutarFormat))} </span>
+            <FormattedNumber num={text} minimumFractionDigits={Number(record?.tutarFormat)} maximumFractionDigits={Number(record?.tutarFormat)} />
           </div>
         ),
         sorter: (a, b) => {
@@ -400,7 +401,7 @@ const GirisFisleri = () => {
         visible: true,
         render: (text, record) => (
           <div className="">
-            <span>{Number(text).toFixed(Number(record?.tutarFormat))} </span>
+            <FormattedNumber num={text} minimumFractionDigits={Number(record?.tutarFormat)} maximumFractionDigits={Number(record?.tutarFormat)} />
           </div>
         ),
         sorter: (a, b) => {
@@ -418,7 +419,7 @@ const GirisFisleri = () => {
         visible: true,
         render: (text, record) => (
           <div className="">
-            <span>{Number(text).toFixed(Number(record?.tutarFormat))} </span>
+            <FormattedNumber num={text} minimumFractionDigits={Number(record?.tutarFormat)} maximumFractionDigits={Number(record?.tutarFormat)} />
           </div>
         ),
         sorter: (a, b) => {

--- a/src/_root/pages/malzeme-depo/GirisFisleri/Table/Table.jsx
+++ b/src/_root/pages/malzeme-depo/GirisFisleri/Table/Table.jsx
@@ -22,6 +22,7 @@ import trTR from "antd/lib/locale/tr_TR";
 import enUS from "antd/lib/locale/en_US";
 import ruRU from "antd/lib/locale/ru_RU";
 import azAZ from "antd/lib/locale/az_AZ";
+import FormattedNumber from "../../../../../hooks/FormattedNumber";
 
 const localeMap = {
   tr: trTR,
@@ -366,7 +367,7 @@ const GirisFisleri = () => {
         visible: true,
         render: (text, record) => (
           <div className="">
-            <span>{Number(text).toFixed(Number(record?.tutarFormat))} </span>
+            <FormattedNumber num={text} minimumFractionDigits={Number(record?.tutarFormat)} maximumFractionDigits={Number(record?.tutarFormat)} />
           </div>
         ),
         sorter: (a, b) => {
@@ -384,7 +385,7 @@ const GirisFisleri = () => {
         visible: true,
         render: (text, record) => (
           <div className="">
-            <span>{Number(text).toFixed(Number(record?.tutarFormat))} </span>
+            <FormattedNumber num={text} minimumFractionDigits={Number(record?.tutarFormat)} maximumFractionDigits={Number(record?.tutarFormat)} />
           </div>
         ),
         sorter: (a, b) => {
@@ -402,7 +403,7 @@ const GirisFisleri = () => {
         visible: true,
         render: (text, record) => (
           <div className="">
-            <span>{Number(text).toFixed(Number(record?.tutarFormat))} </span>
+            <FormattedNumber num={text} minimumFractionDigits={Number(record?.tutarFormat)} maximumFractionDigits={Number(record?.tutarFormat)} />
           </div>
         ),
         sorter: (a, b) => {

--- a/src/_root/pages/malzeme-depo/MalzemeHaraketleri/Table/Table.jsx
+++ b/src/_root/pages/malzeme-depo/MalzemeHaraketleri/Table/Table.jsx
@@ -25,6 +25,7 @@ import trTR from "antd/lib/locale/tr_TR";
 import enUS from "antd/lib/locale/en_US";
 import ruRU from "antd/lib/locale/ru_RU";
 import azAZ from "antd/lib/locale/az_AZ";
+import FormattedNumber from "../../../../../hooks/FormattedNumber";
 
 const localeMap = {
   tr: trTR,
@@ -398,6 +399,7 @@ const MalzemeHareketleri = () => {
         width: 150,
         ellipsis: true,
         visible: true,
+        render: (text) => <FormattedNumber num={text} />,
         sorter: (a, b) => {
           if (a.miktar === null) return -1;
           if (b.miktar === null) return 1;
@@ -424,6 +426,7 @@ const MalzemeHareketleri = () => {
         width: 120,
         ellipsis: true,
         visible: true,
+        render: (text) => <FormattedNumber num={text} />,
         sorter: (a, b) => {
           if (a.fiyat === null) return -1;
           if (b.fiyat === null) return 1;
@@ -437,6 +440,7 @@ const MalzemeHareketleri = () => {
         width: 120,
         ellipsis: true,
         visible: true,
+        render: (text) => <FormattedNumber num={text} />,
         sorter: (a, b) => {
           if (a.toplam === null) return -1;
           if (b.toplam === null) return 1;

--- a/src/_root/pages/malzeme-depo/TransferFisleri/Table/Table.jsx
+++ b/src/_root/pages/malzeme-depo/TransferFisleri/Table/Table.jsx
@@ -22,6 +22,7 @@ import trTR from "antd/lib/locale/tr_TR";
 import enUS from "antd/lib/locale/en_US";
 import ruRU from "antd/lib/locale/ru_RU";
 import azAZ from "antd/lib/locale/az_AZ";
+import FormattedNumber from "../../../../../hooks/FormattedNumber";
 
 const localeMap = {
   tr: trTR,
@@ -366,7 +367,7 @@ const GirisFisleri = () => {
         visible: true,
         render: (text, record) => (
           <div className="">
-            <span>{Number(text).toFixed(Number(record?.tutarFormat))} </span>
+            <FormattedNumber num={text} minimumFractionDigits={Number(record?.tutarFormat)} maximumFractionDigits={Number(record?.tutarFormat)} />
           </div>
         ),
         sorter: (a, b) => {
@@ -384,7 +385,7 @@ const GirisFisleri = () => {
         visible: true,
         render: (text, record) => (
           <div className="">
-            <span>{Number(text).toFixed(Number(record?.tutarFormat))} </span>
+            <FormattedNumber num={text} minimumFractionDigits={Number(record?.tutarFormat)} maximumFractionDigits={Number(record?.tutarFormat)} />
           </div>
         ),
         sorter: (a, b) => {
@@ -402,7 +403,7 @@ const GirisFisleri = () => {
         visible: true,
         render: (text, record) => (
           <div className="">
-            <span>{Number(text).toFixed(Number(record?.tutarFormat))} </span>
+            <FormattedNumber num={text} minimumFractionDigits={Number(record?.tutarFormat)} maximumFractionDigits={Number(record?.tutarFormat)} />
           </div>
         ),
         sorter: (a, b) => {

--- a/src/_root/pages/malzeme-depo/malzeme/Malzemeler.jsx
+++ b/src/_root/pages/malzeme-depo/malzeme/Malzemeler.jsx
@@ -24,6 +24,7 @@ import azAZ from "antd/lib/locale/az_AZ";
 import ReactDOM from "react-dom";
 import { createRoot } from "react-dom/client";
 import * as XLSX from "xlsx";
+import FormattedNumber from "../../../../hooks/FormattedNumber";
 
 const localeMap = {
   tr: trTR,
@@ -409,7 +410,7 @@ const Malzemeler = ({ isSelectionMode = false, onRowSelect, wareHouseId, isCikis
             root.render(<AutoClickModal />);
           }}
         >
-          {text}
+          <FormattedNumber num={text} />
         </Button>
       ),
       sorter: (a, b) => {
@@ -438,6 +439,7 @@ const Malzemeler = ({ isSelectionMode = false, onRowSelect, wareHouseId, isCikis
       width: 100,
       ellipsis: true,
       visible: true,
+      render: (text) => <FormattedNumber num={text} />,
       sorter: (a, b) => {
         if (a.fiyat === null) return -1;
         if (b.fiyat === null) return 1;
@@ -529,6 +531,7 @@ const Malzemeler = ({ isSelectionMode = false, onRowSelect, wareHouseId, isCikis
       width: 100,
       ellipsis: true,
       visible: true,
+      render: (text) => <FormattedNumber num={text} />,
       sorter: (a, b) => {
         if (a.kritikMiktar === null) return -1;
         if (b.kritikMiktar === null) return 1;
@@ -574,6 +577,7 @@ const Malzemeler = ({ isSelectionMode = false, onRowSelect, wareHouseId, isCikis
       width: 120,
       ellipsis: true,
       visible: true,
+      render: (text) => <FormattedNumber num={text} />,
       sorter: (a, b) => {
         if (a.sonFiyat === null) return -1;
         if (b.sonFiyat === null) return 1;
@@ -596,6 +600,7 @@ const Malzemeler = ({ isSelectionMode = false, onRowSelect, wareHouseId, isCikis
       width: 100,
       ellipsis: true,
       visible: true,
+      render: (text) => <FormattedNumber num={text} />,
       sorter: (a, b) => {
         if (a.kdvOran === null) return -1;
         if (b.kdvOran === null) return 1;
@@ -609,6 +614,7 @@ const Malzemeler = ({ isSelectionMode = false, onRowSelect, wareHouseId, isCikis
       width: 100,
       ellipsis: true,
       visible: true,
+      render: (text) => <FormattedNumber num={text} />,
       sorter: (a, b) => {
         if (a.girenMiktar === null) return -1;
         if (b.girenMiktar === null) return 1;
@@ -622,6 +628,7 @@ const Malzemeler = ({ isSelectionMode = false, onRowSelect, wareHouseId, isCikis
       width: 100,
       ellipsis: true,
       visible: true,
+      render: (text) => <FormattedNumber num={text} />,
       sorter: (a, b) => {
         if (a.cikanMiktar === null) return -1;
         if (b.cikanMiktar === null) return 1;


### PR DESCRIPTION
## Summary
- Replaced ad hoc numeric rendering in stock/depot tables with the shared `FormattedNumber` component
- Applied locale-aware formatting to receipt totals, movement amounts, and material price/stock columns
- Kept sorting and existing table behavior unchanged

## Testing
- `npx eslint` on the modified files returned warnings only, with no new errors in the changed code
- `npm run build` completed successfully