### PR TITLE
Remove separator from vehicle statistics cards

### DIFF
--- a/src/_root/pages/vehicles-control/vehicles/components/VehicleStatisticsCards.jsx
+++ b/src/_root/pages/vehicles-control/vehicles/components/VehicleStatisticsCards.jsx
@@ -201,7 +201,6 @@ const VehicleStatisticsCards = ({ request }) => {
               </div>
             </div>
             <div style={{ fontSize: "24px", fontWeight: 700, color: "#141414", marginBottom: "8px", lineHeight: "30px" }}>{formatStatisticValue(statistics.values[index])}</div>
-            <div style={{ borderTop: `1px solid ${CARD_BORDER_COLOR}`, marginBottom: "10px" }} />
             <div style={{ fontSize: "12px", color: "#8c8c8c", lineHeight: "18px", fontWeight: 400 }}>
               {card.subtitle}
             </div>


### PR DESCRIPTION
## Summary
- Removed the horizontal separator line from the vehicle statistics cards
- Kept the card content and spacing otherwise unchanged

## Testing
- Not run (not requested)